### PR TITLE
Parse signed-up users

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This function performs the following steps:
 1. Fetch initial wave energy data and download existing class data from Dropbox.
 2. Launch the browser and log in to the surf registration site.
 3. Loop through the next 10 days to check for available classes.
-4. For each class on the selected date, open its detail popup to capture the list of signed up users.
+4. For each class on the selected date, click its **visibility** button to open the detail popup and capture the list of signed up users.
 5. Compare extracted classes with previously stored classes for the same date.
 6. Store all new classes along with the user lists in the database and prepare notifications.
 7. Send notification message for new, non-recurring classes via Telegram.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This function performs the following steps:
 1. Fetch initial wave energy data and download existing class data from Dropbox.
 2. Launch the browser and log in to the surf registration site.
 3. Loop through the next 10 days to check for available classes.
-4. Extract class data and the list of users signed up for each class for the selected date.
+4. For each class on the selected date, open its detail popup to capture the list of signed up users.
 5. Compare extracted classes with previously stored classes for the same date.
 6. Store all new classes along with the user lists in the database and prepare notifications.
 7. Send notification message for new, non-recurring classes via Telegram.

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ This function performs the following steps:
 1. Fetch initial wave energy data and download existing class data from Dropbox.
 2. Launch the browser and log in to the surf registration site.
 3. Loop through the next 10 days to check for available classes.
-4. Extract class data for the selected date.
+4. Extract class data and the list of users signed up for each class for the selected date.
 5. Compare extracted classes with previously stored classes for the same date.
-6. Store all new classes in the database and prepare notifications.
+6. Store all new classes along with the user lists in the database and prepare notifications.
 7. Send notification message for new, non-recurring classes via Telegram.
 
 ### Telegram Integration

--- a/database.js
+++ b/database.js
@@ -11,6 +11,7 @@ function initializeDatabase() {
                                                    classStartTime TEXT,
                                                    classEndTime TEXT,
                                                    coachName TEXT,
+                                                   signedUpUsers TEXT,
                                                    waveEnergy TEXT,
                                                    notified INTEGER DEFAULT 0
             )`, (err) => {
@@ -18,6 +19,24 @@ function initializeDatabase() {
             console.error("❌ Error initializing database:", err.message);
         } else {
             console.log("✅ Database initialized with `notified` column.");
+        }
+    });
+
+    // Ensure the signedUpUsers column exists for backwards compatibility
+    db.all('PRAGMA table_info(classes);', (err, rows) => {
+        if (err) {
+            console.error('❌ Error checking table info:', err.message);
+            return;
+        }
+        const hasColumn = rows.some(r => r.name === 'signedUpUsers');
+        if (!hasColumn) {
+            db.run('ALTER TABLE classes ADD COLUMN signedUpUsers TEXT;', (alterErr) => {
+                if (alterErr) {
+                    console.error('❌ Error adding signedUpUsers column:', alterErr.message);
+                } else {
+                    console.log('✅ signedUpUsers column added to database.');
+                }
+            });
         }
     });
 }
@@ -38,10 +57,10 @@ function getClassData(date, callback) {
 }
 
 // Function to save a new class record into the database
-function saveClassData(date, className, classTime, classStartTime, classEndTime, coachName, waveEnergy, notified = 0) {
+function saveClassData(date, className, classTime, classStartTime, classEndTime, coachName, signedUpUsers, waveEnergy, notified = 0) {
     db.run(
-        'INSERT INTO classes (date, className, classTime, classStartTime, classEndTime, coachName, waveEnergy, notified) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-        [date, className, classTime, classStartTime, classEndTime, coachName, waveEnergy, notified],
+        'INSERT INTO classes (date, className, classTime, classStartTime, classEndTime, coachName, signedUpUsers, waveEnergy, notified) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [date, className, classTime, classStartTime, classEndTime, coachName, signedUpUsers, waveEnergy, notified],
         function (err) {
             if (err) {
                 console.error('❌ Error saving class data:', err.message);

--- a/surfClassNotifier.js
+++ b/surfClassNotifier.js
@@ -81,6 +81,7 @@ async function checkForNewClasses() {
                 const classElements = document.querySelectorAll('.row.no-gap .col-50[align="left"]');
                 const timeElements = document.querySelectorAll('.row.no-gap .col[align="left"]:not(.col-auto)');
                 const coachElements = document.querySelectorAll('.row.no-gap .col-50[align="right"]');
+                const rows = document.querySelectorAll('.row.no-gap');
                 const classData = [];
 
                 for (let i = 0; i < classElements.length; i++) {
@@ -88,7 +89,17 @@ async function checkForNewClasses() {
                     const classTime = timeElements[i]?.innerText.trim() || 'No time available';  // Default if time missing
                     const coachName = coachElements[i]?.innerText.trim() || 'No coach available';  // Default if coach missing
 
-                    classData.push({ className, classTime, coachName });
+                    let users = [];
+                    const row = rows[i];
+                    if (row) {
+                        let chips = row.querySelectorAll('.chip-label, .chip span, span.user-name');
+                        if (!chips.length && row.nextElementSibling) {
+                            chips = row.nextElementSibling.querySelectorAll('.chip-label, .chip span, span.user-name');
+                        }
+                        users = Array.from(chips).map(el => el.textContent.trim()).filter(Boolean);
+                    }
+
+                    classData.push({ className, classTime, coachName, signedUpUsers: users.join(', ') });
                 }
                 return classData;
             });
@@ -113,7 +124,7 @@ async function checkForNewClasses() {
                     );
                     const energyInfo = waveEnergy ? parseInt(waveEnergy.energy.match(/\d+/)[0], 10) : null;
 
-                    const { className, classTime, coachName } = classData;
+                    const { className, classTime, coachName, signedUpUsers } = classData;
                     const { start, end } = splitClassTime(classTime);
 
                     const isRecurring = recurringClasses.some(recurring =>
@@ -129,6 +140,7 @@ async function checkForNewClasses() {
                         start,
                         end,
                         coachName,
+                        signedUpUsers,
                         energyInfo,
                         notifiedStatus
                     );
@@ -161,7 +173,8 @@ async function checkForNewClasses() {
                         classTime,
                         classStartTime,
                         classEndTime,
-                        coachName
+                        coachName,
+                        signedUpUsers
                     } = classData;
 
                     const period = getPeriodFromClassTime(classTime);
@@ -183,7 +196,8 @@ async function checkForNewClasses() {
                     );
                     const energyInfo = waveEnergy ? parseInt(waveEnergy.energy.match(/\d+/)[0], 10) : null;
 
-                    const entry = `\n[⚡${energyInfo}🏄🗓️️${formattedClassName} (${formattedCoachName})](${calendarLink})`;
+                    const usersInfo = signedUpUsers ? ` - ${signedUpUsers}` : '';
+                    const entry = `\n[⚡${energyInfo}🏄🗓️️${formattedClassName} (${formattedCoachName})](${calendarLink})${usersInfo}`;
 
                     if (
                         className.includes('PERFORMANCE LARANJA') ||

--- a/surfClassNotifier.js
+++ b/surfClassNotifier.js
@@ -100,18 +100,21 @@ async function checkForNewClasses() {
                 const row = rowHandles[item.rowIndex];
                 if (!row) continue;
                 try {
-                    await row.click();
-                    await page.waitForSelector('.popup.detalhes_aula.modal-in', { timeout: 3000 });
-                    const users = await page.evaluate(() => {
-                        return Array.from(document.querySelectorAll('.popup.detalhes_aula.modal-in .list .item-title'))
-                            .map(el => el.textContent.trim())
-                            .filter(Boolean);
-                    });
-                    item.signedUpUsers = users.join(', ');
-                    const back = await page.$('.popup.detalhes_aula.modal-in .but_back a');
-                    if (back) {
-                        await back.click();
-                        await page.waitForSelector('.popup.detalhes_aula.modal-in', { state: 'hidden', timeout: 2000 }).catch(() => {});
+                    const detailBtn = await row.$('a.link.icon-only, a[onclick*="detalhes_aula"]');
+                    if (detailBtn) {
+                        await detailBtn.click();
+                        await page.waitForSelector('.popup.detalhes_aula.modal-in', { timeout: 3000 });
+                        const users = await page.evaluate(() =>
+                            Array.from(document.querySelectorAll('.popup.detalhes_aula.modal-in .list .item-title'))
+                                .map(el => el.textContent.trim())
+                                .filter(Boolean)
+                        );
+                        item.signedUpUsers = users.join(', ');
+                        const back = await page.$('.popup.detalhes_aula.modal-in .but_back a');
+                        if (back) {
+                            await back.click();
+                            await page.waitForSelector('.popup.detalhes_aula.modal-in', { state: 'hidden', timeout: 2000 }).catch(() => {});
+                        }
                     }
                 } catch (err) {
                     console.error('❌ Error retrieving participants:', err.message);


### PR DESCRIPTION
## Summary
- parse users signed up for each class
- store the list in `signedUpUsers` column in the DB
- show the participants alongside class notifications
- document user parsing in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684323f6262883339410f32a78fc08a3